### PR TITLE
add RDCU Interrupt enable/disable function

### DIFF
--- a/lib/rdcu_ctrl.c
+++ b/lib/rdcu_ctrl.c
@@ -463,6 +463,20 @@ uint32_t rdcu_get_adc_logic_enabled(void)
 
 
 /**
+ * @brief get RDCU Interrupt status
+ * @see RDCU-FRS-FN-0632
+ *
+ * @returns 0: Interrupt is disabled
+ *	    1: Interrupt is enabled
+ */
+
+uint32_t rdcu_get_data_compr_active(void)
+{
+	return ((rdcu->compr_status >> 8) & 0x1UL);
+}
+
+
+/**
  * @brief get compressor status valid
  * @see RDCU-FRS-FN-0632
  *
@@ -771,6 +785,28 @@ void rdcu_set_adc_logic_enabled(void)
 void rdcu_set_adc_logic_disabled(void)
 {
 	rdcu->adc_ctrl &= ~0x1UL;
+}
+
+
+/**
+ * @brief enabled RDCU interrupt
+ * @see RDCU-FRS-FN-0732
+ */
+
+void rdcu_set_data_compr_start(void)
+{
+	rdcu->compr_ctrl |= (0x1UL << 8);
+}
+
+
+/**
+ * @brief disabled RDCU interrupt
+ * @see RDCU-FRS-FN-0732
+ */
+
+void rdcu_clear_data_compr_start(void)
+{
+	rdcu->compr_ctrl &= ~(0x1UL << 8);
 }
 
 


### PR DESCRIPTION
Added the required function to enable RDCU interruption, see PLATO-IWF-PL-RS-005 Issue No. 1.0