### PR TITLE
add RDCU Interrupt enable/disable fuction

### DIFF
--- a/include/rdcu_ctrl.h
+++ b/include/rdcu_ctrl.h
@@ -164,6 +164,7 @@ uint32_t rdcu_get_adc_logic_reset(void);
 uint32_t rdcu_get_adc_logic_enabled(void);
 
 
+uint32_t rdcu_get_rdcu_interrupt_enabled(void);
 uint32_t rdcu_get_compr_status_valid(void);
 uint32_t rdcu_get_data_compr_ready(void);
 uint32_t rdcu_get_data_compr_interrupted(void);
@@ -194,6 +195,8 @@ void rdcu_clear_adc_logic_reset(void);
 void rdcu_set_adc_logic_enabled(void);
 void rdcu_set_adc_logic_disabled(void);
 
+void rdcu_set_rdcu_interrupt(void);
+void rdcu_clear_rdcu_interrupt(void);
 void rdcu_set_data_compr_interrupt(void);
 void rdcu_clear_data_compr_interrupt(void);
 void rdcu_set_data_compr_start(void);

--- a/lib/rdcu_ctrl.c
+++ b/lib/rdcu_ctrl.c
@@ -462,6 +462,20 @@ uint32_t rdcu_get_adc_logic_enabled(void)
 }
 
 
+/*
+ * @brief get RDCU Interrupt status
+ * @see RDCU-FRS-FN-0632
+ *
+ * @returns 0: Interrupt is disabled
+ *	    1: Interrupt is enabled
+ */
+
+uint32_t rdcu_get_rdcu_interrupt_enabled(void)
+{
+	return ((rdcu->compr_status >> 8) & 0x1UL);
+}
+
+
 /**
  * @brief get compressor status valid
  * @see RDCU-FRS-FN-0632
@@ -771,6 +785,28 @@ void rdcu_set_adc_logic_enabled(void)
 void rdcu_set_adc_logic_disabled(void)
 {
 	rdcu->adc_ctrl &= ~0x1UL;
+}
+
+
+/**
+ * @brief enable RDCU interrupt signal to the ICU
+ * @see RDCU-FRS-FN-0732
+ */
+
+void rdcu_set_rdcu_interrupt(void)
+{
+	rdcu->compr_ctrl |= (0x1UL << 8);
+}
+
+
+/**
+ * @brief disable RDCU interrupt signal to the ICU
+ * @see RDCU-FRS-FN-0732
+ */
+
+void rdcu_clear_rdcu_interrupt(void)
+{
+	rdcu->compr_ctrl &= ~(0x1UL << 8);
 }
 
 


### PR DESCRIPTION
Update the need to enable function for RDCU Interrupt, see PLATO-IWF-PL-RS-005 Issue No. 1.0