### PR TITLE
clarifies the naming of cmp_size

### DIFF
--- a/demo_plato_rdcu.c
+++ b/demo_plato_rdcu.c
@@ -629,12 +629,12 @@ static void rdcu_compression_demo(void)
 
 	rdcu_sync_compr_data_size();
 	sync();
-	printf("Compressed data size: %ld\n", rdcu_get_compr_data_size_bit() >> 3);
+	printf("Compressed data size: %ld\n", (rdcu_get_compr_data_size_bit() + 7) >> 3);
 
 
 	/* issue sync back of compressed data */
 	if (rdcu_sync_sram_to_mirror(COMPRSTART,
-				     (((rdcu_get_compr_data_size_bit() >> 3) + 3) & ~0x3UL),
+				     ((((rdcu_get_compr_data_size_bit() + 7) >> 3) + 3) & ~0x3UL),
 				     rdcu_get_data_mtu())) {
 		printf("error in rdcu_sync_ram_to_mirror!\n");
 	}
@@ -645,7 +645,7 @@ static void rdcu_compression_demo(void)
 	/* read compressed data to some buffer and print */
 	if (1) {
 		uint32_t i;
-		uint32_t s = rdcu_get_compr_data_size_bit() >> 3;
+		uint32_t s = (rdcu_get_compr_data_size_bit() + 7) >> 3;
 		uint8_t *myresult = malloc(s);
 		rdcu_read_sram(myresult, COMPRSTART, s);
 
@@ -760,7 +760,7 @@ static void rdcu_compression_cmp_lib_demo(void)
 
 	if (1) {
 		uint32_t i;
-		uint32_t s = size_of_model(example_info.samples_used,
+		uint32_t s = cmp_cal_size_of_model(example_info.samples_used,
 					   example_info.cmp_mode_used);
 		uint8_t *mymodel = malloc(s);
 

--- a/demo_plato_rdcu.c
+++ b/demo_plato_rdcu.c
@@ -629,12 +629,12 @@ static void rdcu_compression_demo(void)
 
 	rdcu_sync_compr_data_size();
 	sync();
-	printf("Compressed data size: %ld\n", rdcu_get_compr_data_size() >> 3);
+	printf("Compressed data size: %ld\n", rdcu_get_compr_data_size_bit() >> 3);
 
 
 	/* issue sync back of compressed data */
 	if (rdcu_sync_sram_to_mirror(COMPRSTART,
-				     (((rdcu_get_compr_data_size() >> 3) + 3) & ~0x3UL),
+				     (((rdcu_get_compr_data_size_bit() >> 3) + 3) & ~0x3UL),
 				     rdcu_get_data_mtu())) {
 		printf("error in rdcu_sync_ram_to_mirror!\n");
 	}
@@ -645,7 +645,7 @@ static void rdcu_compression_demo(void)
 	/* read compressed data to some buffer and print */
 	if (1) {
 		uint32_t i;
-		uint32_t s = rdcu_get_compr_data_size() >> 3;
+		uint32_t s = rdcu_get_compr_data_size_bit() >> 3;
 		uint8_t *myresult = malloc(s);
 		rdcu_read_sram(myresult, COMPRSTART, s);
 
@@ -734,7 +734,7 @@ static void rdcu_compression_cmp_lib_demo(void)
 	/* read compressed data to some buffer and print */
 	if (1) {
 		uint32_t i;
-		uint32_t s = size_of_bitstream(example_info.cmp_size);
+		uint32_t s = example_info.cmp_size_byte;
 		uint8_t *myresult = malloc(s);
 
 		if (!myresult) {

--- a/include/cmp_support.h
+++ b/include/cmp_support.h
@@ -125,7 +125,7 @@ struct cmp_status {
  *      executed compression of the HW as well as the SW compressor.
  *
  * @note if SW compression is used the parameters rdcu_model_adr_used, rdcu_cmp_adr_used,
- *      ap1_cmp_size, ap2_cmp_size are not used and are therefore set to zero
+ *      ap1_cmp_size_byte, ap2_cmp_size_byte are not used and are therefore set to zero
  */
 
 struct cmp_info {
@@ -135,9 +135,9 @@ struct cmp_info {
 	uint32_t spill_used;          /* Spillover threshold used */
 	uint32_t golomb_par_used;     /* Golomb parameter used */
 	uint32_t samples_used;        /* Number of samples (16 bit value) to be stored */
-	uint32_t cmp_size;            /* Compressed data size; measured in bits */
-	uint32_t ap1_cmp_size;        /* Adaptive compressed data size 1; measured in bits */
-	uint32_t ap2_cmp_size;        /* Adaptive compressed data size 2; measured in bits */
+	uint32_t cmp_size_byte;       /* Compressed data size; measured in bytes */
+	uint32_t ap1_cmp_size_byte;  /* Adaptive compressed data size 1; measured in bytes */
+	uint32_t ap2_cmp_size_byte;  /* Adaptive compressed data size 2; measured in bytes */
 	uint32_t rdcu_new_model_adr_used; /* Updated model start  address used */
 	uint32_t rdcu_cmp_adr_used;   /* Compressed data start address */
 	uint16_t cmp_err;             /* Compressor errors
@@ -172,7 +172,8 @@ unsigned int cal_up_model(unsigned int data, unsigned int model, unsigned int
 uint32_t get_max_spill(unsigned int golomb_par, unsigned int cmp_mode);
 
 size_t size_of_a_sample(unsigned int cmp_mode);
-unsigned int size_of_bitstream(unsigned int cmp_size);
+unsigned int cmp_bit_to_4byte(unsigned int cmp_size_bit);
+unsigned int size_of_data(unsigned int samples, unsigned int cmp_mode);
 unsigned int size_of_model(unsigned int samples, unsigned int cmp_mode);
 
 void print_cmp_cfg(const struct cmp_cfg *cfg);

--- a/include/cmp_support.h
+++ b/include/cmp_support.h
@@ -173,8 +173,8 @@ uint32_t get_max_spill(unsigned int golomb_par, unsigned int cmp_mode);
 
 size_t size_of_a_sample(unsigned int cmp_mode);
 unsigned int cmp_bit_to_4byte(unsigned int cmp_size_bit);
-unsigned int size_of_data(unsigned int samples, unsigned int cmp_mode);
-unsigned int size_of_model(unsigned int samples, unsigned int cmp_mode);
+unsigned int cmp_cal_size_of_data(unsigned int samples, unsigned int cmp_mode);
+unsigned int cmp_cal_size_of_model(unsigned int samples, unsigned int cmp_mode);
 
 void print_cmp_cfg(const struct cmp_cfg *cfg);
 void print_cmp_info(const struct cmp_info *info);

--- a/include/rdcu_ctrl.h
+++ b/include/rdcu_ctrl.h
@@ -244,11 +244,14 @@ uint32_t rdcu_get_golomb_param(void);
 
 uint32_t rdcu_get_compr_data_start_addr(void);
 
-uint32_t rdcu_get_compr_data_size(void);
+uint32_t rdcu_get_compr_data_size_bit(void);
+uint32_t rdcu_get_compr_data_size_byte(void);
 
-uint32_t rdcu_get_compr_data_adaptive_1_size(void);
+uint32_t rdcu_get_compr_data_adaptive_1_size_bit(void);
+uint32_t rdcu_get_compr_data_adaptive_1_size_byte(void);
 
-uint32_t rdcu_get_compr_data_adaptive_2_size(void);
+uint32_t rdcu_get_compr_data_adaptive_2_size_bit(void);
+uint32_t rdcu_get_compr_data_adaptive_2_size_byte(void);
 
 uint16_t rdcu_get_compr_error(void);
 

--- a/lib/cmp_rdcu.c
+++ b/lib/cmp_rdcu.c
@@ -19,6 +19,7 @@
 
 #include <stdint.h>
 #include <stdio.h>
+#include <limits.h>
 
 #include "../include/rdcu_cmd.h"
 #include "../include/cmp_support.h"
@@ -632,9 +633,9 @@ int rdcu_read_cmp_info(struct cmp_info *info)
 		info->rdcu_new_model_adr_used = rdcu_get_new_model_addr_used();
 		info->samples_used = rdcu_get_samples_used();
 		info->rdcu_cmp_adr_used = rdcu_get_compr_data_start_addr();
-		info->cmp_size = rdcu_get_compr_data_size();
-		info->ap1_cmp_size = rdcu_get_compr_data_adaptive_1_size();
-		info->ap2_cmp_size = rdcu_get_compr_data_adaptive_2_size();
+		info->cmp_size_byte = rdcu_get_compr_data_size_byte();
+		info->ap1_cmp_size_byte = rdcu_get_compr_data_adaptive_1_size_byte();
+		info->ap2_cmp_size_byte = rdcu_get_compr_data_adaptive_2_size_byte();
 		info->cmp_err = rdcu_get_compr_error();
 	}
 	return 0;
@@ -659,11 +660,14 @@ int rdcu_read_cmp_bitstream(const struct cmp_info *info, void *output_buf)
 	if (info == NULL)
 		return -1;
 
-	/* calculate the need bytes for the bitstream */
-	s = size_of_bitstream(info->cmp_size);
+	s = info->cmp_size_byte;
 
-	if (output_buf == NULL)
-		return (int)s;
+	if (output_buf == NULL) {
+		if (s <= INT_MAX)
+			return (int)s;
+		else
+			return -1;
+	}
 
 	if (rdcu_sync_sram_to_mirror(info->rdcu_cmp_adr_used, s,
 				     rdcu_get_data_mtu()))

--- a/lib/cmp_rdcu.c
+++ b/lib/cmp_rdcu.c
@@ -669,7 +669,8 @@ int rdcu_read_cmp_bitstream(const struct cmp_info *info, void *output_buf)
 			return -1;
 	}
 
-	if (rdcu_sync_sram_to_mirror(info->rdcu_cmp_adr_used, s,
+	/* we round up the size s to multiples of 4 bytes */
+	if (rdcu_sync_sram_to_mirror(info->rdcu_cmp_adr_used, (s+3) & ~3UL,
 				     rdcu_get_data_mtu()))
 		return -1;
 
@@ -699,7 +700,7 @@ int rdcu_read_model(const struct cmp_info *info, void *model_buf)
 		return -1;
 
 	/* calculate the need bytes for the model */
-	s = size_of_model(info->samples_used, info->cmp_mode_used);
+	s = cmp_cal_size_of_model(info->samples_used, info->cmp_mode_used);
 
 	if (model_buf == NULL) {
 		if (s <= INT_MAX)
@@ -708,7 +709,8 @@ int rdcu_read_model(const struct cmp_info *info, void *model_buf)
 			return -1;
 	}
 
-	if (rdcu_sync_sram_to_mirror(info->rdcu_new_model_adr_used, (s+3) & ~3U,
+	/* we round up the size to multiples of 4 bytes */
+	if (rdcu_sync_sram_to_mirror(info->rdcu_new_model_adr_used, (s+3) & ~3UL,
 				     rdcu_get_data_mtu()))
 		return -1;
 

--- a/lib/cmp_rdcu.c
+++ b/lib/cmp_rdcu.c
@@ -701,8 +701,12 @@ int rdcu_read_model(const struct cmp_info *info, void *model_buf)
 	/* calculate the need bytes for the model */
 	s = size_of_model(info->samples_used, info->cmp_mode_used);
 
-	if (model_buf == NULL)
-		return (int)s;
+	if (model_buf == NULL) {
+		if (s <= INT_MAX)
+			return (int)s;
+		else
+			return -1;
+	}
 
 	if (rdcu_sync_sram_to_mirror(info->rdcu_new_model_adr_used, (s+3) & ~3U,
 				     rdcu_get_data_mtu()))

--- a/lib/cmp_support.c
+++ b/lib/cmp_support.c
@@ -521,7 +521,7 @@ unsigned int cmp_bit_to_4byte(unsigned int cmp_size_bit)
  * @returns the size in bytes to store the data sample
  */
 
-unsigned int size_of_data(unsigned int samples, unsigned int cmp_mode)
+unsigned int cmp_cal_size_of_data(unsigned int samples, unsigned int cmp_mode)
 {
 	return samples * size_of_a_sample(cmp_mode);
 }
@@ -536,9 +536,9 @@ unsigned int size_of_data(unsigned int samples, unsigned int cmp_mode)
  * @returns the size in bytes to store the model sample
  */
 
-unsigned int size_of_model(unsigned int samples, unsigned int cmp_mode)
+unsigned int cmp_cal_size_of_model(unsigned int samples, unsigned int cmp_mode)
 {
-	return size_of_data(samples, cmp_mode);
+	return cmp_cal_size_of_data(samples, cmp_mode);
 }
 
 

--- a/lib/cmp_support.c
+++ b/lib/cmp_support.c
@@ -500,28 +500,45 @@ size_t size_of_a_sample(unsigned int cmp_mode)
 /**
  * @brief calculate the need bytes to hold a bitstream
  *
- * @param cmp_size compressed data size, measured in bits
+ * @param cmp_size_bit compressed data size, measured in bits
  *
- * @returns the size in bytes to sore the hole bitstream
+ * @returns the size in bytes to store the hole bitstream
+ * @note we round up the result to multiples of 4 bytes
  */
 
-unsigned int size_of_bitstream(unsigned int cmp_size)
+unsigned int cmp_bit_to_4byte(unsigned int cmp_size_bit)
 {
-	return (((cmp_size >> 3) + 3) & ~0x3U);
+	return (((cmp_size_bit + 7) / 8) + 3) & ~0x3UL;
+}
+
+
+/**
+ * @brief calculate the need bytes for the data
+ *
+ * @param samples number of data samples
+ * @param cmp_mode used compression mode
+ *
+ * @returns the size in bytes to store the data sample
+ */
+
+unsigned int size_of_data(unsigned int samples, unsigned int cmp_mode)
+{
+	return samples * size_of_a_sample(cmp_mode);
 }
 
 
 /**
  * @brief calculate the need bytes for the model
  *
- * @param cmp_size compressed data size, measured in bits
+ * @param samples number of model samples
+ * @param cmp_mode used compression mode
  *
- * @returns the size in bytes to sore the hole bitstream
+ * @returns the size in bytes to store the model sample
  */
 
 unsigned int size_of_model(unsigned int samples, unsigned int cmp_mode)
 {
-	return samples * size_of_a_sample(cmp_mode);
+	return size_of_data(samples, cmp_mode);
 }
 
 
@@ -587,9 +604,9 @@ void print_cmp_info(const struct cmp_info *info)
 	printf("spill_used: %lu\n", info->spill_used);
 	printf("golomb_par_used: %lu\n", info->golomb_par_used);
 	printf("samples_used: %lu\n", info->samples_used);
-	printf("cmp_size: %lu\n", info->cmp_size);
-	printf("ap1_cmp_size: %lu\n", info->ap1_cmp_size);
-	printf("ap2_cmp_size: %lu\n", info->ap2_cmp_size);
+	printf("cmp_size_byte: %lu\n", info->cmp_size_byte);
+	printf("ap1_cmp_size_byte: %lu\n", info->ap1_cmp_size_byte);
+	printf("ap2_cmp_size_byte: %lu\n", info->ap2_cmp_size_byte);
 	printf("rdcu_new_model_adr_used: 0x%06lX\n", info->rdcu_new_model_adr_used);
 	printf("rdcu_cmp_adr_used: 0x%06lX\n", info->rdcu_cmp_adr_used);
 	printf("cmp_err: %#X\n", info->cmp_err);

--- a/lib/rdcu_ctrl.c
+++ b/lib/rdcu_ctrl.c
@@ -1305,41 +1305,95 @@ uint32_t rdcu_get_compr_data_start_addr(void)
 
 
 /**
- * @brief get compressed data size
+ * @brief get the need bytes for the given bits
+ *
+ * @param cmp_size_bit compressed data size, measured in bits
+ *
+ * @returns the size in bytes to store the compressed data
+ * @note we round up the result to multiples of 4 bytes
+ */
+
+static uint32_t rdcu_bit_to_4byte(unsigned int cmp_size_bit)
+{
+	return (((cmp_size_bit + 7) / 8) + 3) & ~0x3UL;
+}
+
+
+/**
+ * @brief get compressed data size in bits
  * @see RDCU-FRS-FN-0922
  *
  * @returns the compressed data size in bits
  */
 
-uint32_t rdcu_get_compr_data_size(void)
+uint32_t rdcu_get_compr_data_size_bit(void)
 {
 	return rdcu->compr_data_size;
 }
 
 
 /**
- * @brief get compressed data adaptive 1 size
+ * @brief get compressed data size in bytes
+ * @see RDCU-FRS-FN-0922
+ *
+ * @returns the compressed data size in bytes
+ */
+
+uint32_t rdcu_get_compr_data_size_byte(void)
+{
+	return rdcu_bit_to_4byte(rdcu_get_compr_data_size_bit());
+}
+
+
+/**
+ * @brief get compressed data adaptive 1 size in bits
  * @see RDCU-FRS-FN-0932
  *
  * @returns the adaptive 1 compressed data size in bits
  */
 
-uint32_t rdcu_get_compr_data_adaptive_1_size(void)
+uint32_t rdcu_get_compr_data_adaptive_1_size_bit(void)
 {
 	return rdcu->compr_data_adaptive_1_size;
 }
 
 
 /**
- * @brief get compressed data adaptive 2 size
+ * @brief get compressed data adaptive 1 size in bytes
+ * @see RDCU-FRS-FN-0932
+ *
+ * @returns the adaptive 1 compressed data size in bytes
+ */
+
+uint32_t rdcu_get_compr_data_adaptive_1_size_byte(void)
+{
+	return rdcu_bit_to_4byte(rdcu_get_compr_data_adaptive_1_size_bit());
+}
+
+
+/**
+ * @brief get compressed data adaptive 2 size in bits
  * @see RDCU-FRS-FN-0942
  *
  * @returns the adaptive 2 compressed data size in bits
  */
 
-uint32_t rdcu_get_compr_data_adaptive_2_size(void)
+uint32_t rdcu_get_compr_data_adaptive_2_size_bit(void)
 {
 	return rdcu->compr_data_adaptive_2_size;
+}
+
+
+/**
+ * @brief get compressed data adaptive 2 size in bytes
+ * @see RDCU-FRS-FN-0942
+ *
+ * @returns the adaptive 2 compressed data size in bytes
+ */
+
+uint32_t rdcu_get_compr_data_adaptive_2_size_byte(void)
+{
+	return rdcu_bit_to_4byte(rdcu_get_compr_data_adaptive_2_size_bit());
 }
 
 

--- a/lib/rdcu_ctrl.c
+++ b/lib/rdcu_ctrl.c
@@ -1310,12 +1310,11 @@ uint32_t rdcu_get_compr_data_start_addr(void)
  * @param cmp_size_bit compressed data size, measured in bits
  *
  * @returns the size in bytes to store the compressed data
- * @note we round up the result to multiples of 4 bytes
  */
 
-static uint32_t rdcu_bit_to_4byte(unsigned int cmp_size_bit)
+static uint32_t rdcu_bit_to_byte(unsigned int cmp_size_bit)
 {
-	return (((cmp_size_bit + 7) / 8) + 3) & ~0x3UL;
+	return ((cmp_size_bit + 7) / 8);
 }
 
 
@@ -1341,7 +1340,7 @@ uint32_t rdcu_get_compr_data_size_bit(void)
 
 uint32_t rdcu_get_compr_data_size_byte(void)
 {
-	return rdcu_bit_to_4byte(rdcu_get_compr_data_size_bit());
+	return rdcu_bit_to_byte(rdcu_get_compr_data_size_bit());
 }
 
 
@@ -1367,7 +1366,7 @@ uint32_t rdcu_get_compr_data_adaptive_1_size_bit(void)
 
 uint32_t rdcu_get_compr_data_adaptive_1_size_byte(void)
 {
-	return rdcu_bit_to_4byte(rdcu_get_compr_data_adaptive_1_size_bit());
+	return rdcu_bit_to_byte(rdcu_get_compr_data_adaptive_1_size_bit());
 }
 
 
@@ -1393,7 +1392,7 @@ uint32_t rdcu_get_compr_data_adaptive_2_size_bit(void)
 
 uint32_t rdcu_get_compr_data_adaptive_2_size_byte(void)
 {
-	return rdcu_bit_to_4byte(rdcu_get_compr_data_adaptive_2_size_bit());
+	return rdcu_bit_to_byte(rdcu_get_compr_data_adaptive_2_size_bit());
 }
 
 


### PR DESCRIPTION
The rdcu hw compressor stores the length of the compressed data in the cmp_size register. Since _size implements a length in bytes, a _bit or _byte postfix has been added to all cmp_size functions and variables to make it clear in which unit the compressed data is measured.