### PR TITLE
Adaptation to the INAF compiler setup 

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,12 +1,12 @@
 CC_SPARK  = sparc-elf-gcc
 CC_SPARK_AVAILABLE := $(shell command -v $(CC_SPARK) 2> /dev/null)
-MOREFLAGS_SPARC = -O2 -mv8 -Wno-long-long -Wno-missing-field-initializers
+MOREFLAGS_SPARC = -std=gnu89 -O2
 LIBDIR    = ../lib
 CPPFLAGS += -DNO_IASW -I$(LIBDIR) -I$(LIBDIR)/common
 DEBUGFLAGS= -Wall -Wextra -pedantic -Wcast-qual -Wshadow \
             -Wstrict-aliasing=1 -Wdeclaration-after-statement \
             -Wstrict-prototypes -Wpointer-arith \
-            -Wvla -Wformat=2 -Winit-self -Wfloat-equal -Wwrite-strings \
+            -Wformat=2 -Winit-self -Wfloat-equal -Wwrite-strings \
             #-Wcast-align -Wredundant-decls -Wmissing-prototypes -Wundef -Wswitch-enum
 CFLAGS   += $(DEBUGFLAGS) $(MOREFLAGS)
 LIB       = $(LIBDIR)/libcmp.a

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,8 +1,8 @@
 CC_SPARK  = sparc-elf-gcc
 CC_SPARK_AVAILABLE := $(shell command -v $(CC_SPARK) 2> /dev/null)
-MOREFLAGS_SPARC = -std=gnu89 -O2
+MOREFLAGS_SPARC = -O2
 LIBDIR    = ../lib
-CPPFLAGS += -DNO_IASW -I$(LIBDIR) -I$(LIBDIR)/common
+CPPFLAGS += -std=gnu99 -DNO_IASW -I$(LIBDIR) -I$(LIBDIR)/common
 DEBUGFLAGS= -Wall -Wextra -pedantic -Wcast-qual -Wshadow \
             -Wstrict-aliasing=1 -Wdeclaration-after-statement \
             -Wstrict-prototypes -Wpointer-arith \

--- a/examples/demo_plato_rdcu.c
+++ b/examples/demo_plato_rdcu.c
@@ -365,7 +365,7 @@ static void gr718b_cfg_router(void)
  * @note prints abort message if pending status is non-zero after 10 retries
  */
 
-static void sync(void)
+static void demo_sync(void)
 {
 	int cnt = 0;
 	printf("syncing...");
@@ -391,7 +391,7 @@ static void rdcu_show_rmap_errors(void)
 	rdcu_sync_rmap_no_reply_err_cntrs();
 	rdcu_sync_rmap_last_err();
 	rdcu_sync_rmap_pckt_err_cntrs();
-	sync();
+	demo_sync();
 
 	printf("RMAP incomplete header errors %d\n",
 	       rdcu_get_rmap_incomplete_hdrs());
@@ -460,7 +460,7 @@ static void rdcu_verify_data_transfers(void)
 	/* now sync the sram chunks to the RDCU */
 	if (rdcu_sync_mirror_to_sram(DATASTART, RDCU_SRAM_SIZE, rdcu_get_data_mtu()))
 		printf("BIG FAT TRANSFER ERROR!\n");
-	sync();
+	demo_sync();
 	printf("\nDONE\n");
 
 	printf("Zeroing mirror...\n");
@@ -471,7 +471,7 @@ static void rdcu_verify_data_transfers(void)
 	/* now sync the sram chunks to the RDCU */
 	if (rdcu_sync_sram_to_mirror(DATASTART, RDCU_SRAM_SIZE, rdcu_get_data_mtu()))
 		printf("BIG FAT TRANSFER ERROR!\n");
-	sync();
+	demo_sync();
 	printf("\nDONE\n");
 
 
@@ -549,7 +549,7 @@ static void rdcu_compression_demo(void)
 	rdcu_sync_num_samples();
 
 	/* ...and wait for completion */
-	sync();
+	demo_sync();
 
 
 	/* now set the data in the local mirror... */
@@ -564,13 +564,13 @@ static void rdcu_compression_demo(void)
 
 
 	/* wait */
-	sync();
+	demo_sync();
 
 
 	printf("Configuring compression start bit and starting compression\n");
 	rdcu_set_data_compr_start();
 	rdcu_sync_compr_ctrl();
-	sync();
+	demo_sync();
 
 	/* clear local bit immediately, this is a write-only register.
 	 * we would not want to restart compression by accidentially calling
@@ -581,13 +581,13 @@ static void rdcu_compression_demo(void)
 
 	/* start polling the compression status */
 	rdcu_sync_compr_status();
-	sync();
+	demo_sync();
 	cnt = 0;
 	while (!rdcu_get_data_compr_ready()) {
 
 		/* check compression status */
 		rdcu_sync_compr_status();
-		sync();
+		demo_sync();
 		cnt++;
 
 		if (cnt < 5)	/* wait for 5 polls */
@@ -599,12 +599,12 @@ static void rdcu_compression_demo(void)
 
 		rdcu_set_data_compr_interrupt();
 		rdcu_sync_compr_ctrl();
-		sync();
+		demo_sync();
 		rdcu_clear_data_compr_interrupt(); /* always clear locally */
 
 		/* now we may read the error code */
 		rdcu_sync_compr_error();
-		sync();
+		demo_sync();
 		printf("Compressor error code: 0x%02X\n",
 		       rdcu_get_compr_error());
 
@@ -621,13 +621,13 @@ static void rdcu_compression_demo(void)
 
 	/* now we may read the error code */
 	rdcu_sync_compr_error();
-	sync();
+	demo_sync();
 	printf("Compressor error code: 0x%02X\n",
 	       rdcu_get_compr_error());
 
 
 	rdcu_sync_compr_data_size();
-	sync();
+	demo_sync();
 	printf("Compressed data size: %ld\n", (rdcu_get_compr_data_size_bit() + 7) >> 3);
 
 
@@ -639,7 +639,7 @@ static void rdcu_compression_demo(void)
 	}
 
 	/* wait for it */
-	sync();
+	demo_sync();
 
 	/* read compressed data to some buffer and print */
 	if (1) {
@@ -1067,7 +1067,7 @@ static void rdcu_demo(void)
 	rdcu_sync_fpga_version();
 	rdcu_sync_compr_status();
 	rdcu_sync_rdcu_status();
-	sync();
+	demo_sync();
 	printf("Current FPGA version: %d.%d\n", rdcu_get_fpga_version()>>8, rdcu_get_fpga_version()&0xFF);
 	printf("Compressor status ready: %s\n",
 	       rdcu_get_data_compr_ready() ? "yes" : "no");
@@ -1086,10 +1086,10 @@ static void rdcu_demo(void)
 		       "access the data compressor control registers\n");
 		rdcu_set_data_compr_interrupt();
 		rdcu_sync_compr_ctrl();
-		sync();
+		demo_sync();
 		rdcu_clear_data_compr_interrupt(); /* always clear locally */
 		rdcu_sync_compr_status(); /* read back status */
-		sync();
+		demo_sync();
 
 		if (rdcu_get_data_compr_active()) {
 			printf("ERRROR: compressor still active, aborting\n");
@@ -1101,9 +1101,9 @@ static void rdcu_demo(void)
 	/* change the RDCU link speed to 100 Mbit (divider:1 -> CLKDIV:0) */
 	rdcu_set_spw_link_run_clkdiv(0);
 	rdcu_sync_spw_link_ctrl();
-	sync();
+	demo_sync();
 	rdcu_sync_spw_link_status();
-	sync();
+	demo_sync();
 	printf("RDCU linkdiv now set to: %d\n", rdcu_get_spw_run_clk_div() + 1);
 
 
@@ -1180,7 +1180,7 @@ int main(void)
 	/* update target logical address in RDCU core control */
 	rdcu_set_rmap_target_logical_address(RDCU_ADDR);
 	rdcu_sync_core_ctrl();
-	sync();
+	demo_sync();
 
 
 	/* a direct route has been configured and the remote logical address

--- a/examples/example_cmp_icu.c
+++ b/examples/example_cmp_icu.c
@@ -22,6 +22,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include <leon_inttypes.h>
+
 #include <cmp_entity.h>
 #include <cmp_icu.h>
 
@@ -140,7 +142,7 @@ int demo_icu_compression(void) {
 		goto fail;
 	}
 
-	printf("Here's the compressed entity (size %u):\n"
+	printf("Here's the compressed entity (size %"PRIu32"):\n"
 	       "=========================================\n", entity_size);
 	for (i = 0; i < entity_size; i++) {
 		uint8_t *p = (uint8_t *)cmp_entity; /* the compression entity is big-endian */
@@ -168,5 +170,5 @@ fail:
 
 int main(void)
 {
-	demo_icu_compression();
+	return demo_icu_compression();
 }

--- a/examples/leon/irq_dispatch.c
+++ b/examples/leon/irq_dispatch.c
@@ -66,7 +66,7 @@ int catch_interrupt(__attribute__((unused)) int func,
 	return 0;
 }
 #else
-#include <asm-leon/irq.h>
+#include "irq.h"
 #endif
 
 

--- a/examples/leon/leon_reg.h
+++ b/examples/leon/leon_reg.h
@@ -24,14 +24,6 @@
 
 #include <stdint.h>
 
-/**
- * helper macro to fill unused 4-byte slots with "unusedXX" variables
- * yes, this needs to be done exactly like that, or __COUNTER__ will not be expanded
- */
-#define CONCAT(x, y)		x##y
-#define MACRO_CONCAT(x, y) 	CONCAT(x, y)
-#define UNUSED_UINT32_SLOT	 uint32_t MACRO_CONCAT(unused, __COUNTER__)
-
 
 #define CORE1553BRM_REG_BASE		0xFFF00000
 
@@ -82,48 +74,48 @@ struct leon3_irqctrl_registermap {
 	uint32_t irq_clear;			/* 0x0C */
 	uint32_t mp_status;			/* 0x10 */
 	uint32_t mp_broadcast;			/* 0x14 */
-	UNUSED_UINT32_SLOT;			/* 0x18 */
-	UNUSED_UINT32_SLOT;			/* 0x1C */
-	UNUSED_UINT32_SLOT;			/* 0x20 */
-	UNUSED_UINT32_SLOT;			/* 0x24 */
-	UNUSED_UINT32_SLOT;			/* 0x28 */
-	UNUSED_UINT32_SLOT;			/* 0x2C */
-	UNUSED_UINT32_SLOT;			/* 0x30 */
-	UNUSED_UINT32_SLOT;			/* 0x34 */
-	UNUSED_UINT32_SLOT;			/* 0x38 */
-	UNUSED_UINT32_SLOT;			/* 0x3C */
+	uint32_t unused_0;			/* 0x18 */
+	uint32_t unused_1;			/* 0x1C */
+	uint32_t unused_2;			/* 0x20 */
+	uint32_t unused_3;			/* 0x24 */
+	uint32_t unused_4;			/* 0x28 */
+	uint32_t unused_5;			/* 0x2C */
+	uint32_t unused_6;			/* 0x30 */
+	uint32_t unused_7;			/* 0x34 */
+	uint32_t unused_8;			/* 0x38 */
+	uint32_t unused_9;			/* 0x3C */
 	uint32_t irq_mpmask[2];			/* 0x40 CPU 0 */
 						/* 0x44 CPU 1 */
-	UNUSED_UINT32_SLOT;			/* 0x48 */
-	UNUSED_UINT32_SLOT;			/* 0x4C */
-	UNUSED_UINT32_SLOT;			/* 0x50 */
-	UNUSED_UINT32_SLOT;			/* 0x54 */
-	UNUSED_UINT32_SLOT;			/* 0x58 */
-	UNUSED_UINT32_SLOT;			/* 0x5C */
-	UNUSED_UINT32_SLOT;			/* 0x60 */
-	UNUSED_UINT32_SLOT;			/* 0x64 */
-	UNUSED_UINT32_SLOT;			/* 0x68 */
-	UNUSED_UINT32_SLOT;			/* 0x6C */
-	UNUSED_UINT32_SLOT;			/* 0x70 */
-	UNUSED_UINT32_SLOT;			/* 0x74 */
-	UNUSED_UINT32_SLOT;			/* 0x78 */
-	UNUSED_UINT32_SLOT;			/* 0x7C */
+	uint32_t unused_10;			/* 0x48 */
+	uint32_t unused_11;			/* 0x4C */
+	uint32_t unused_12;			/* 0x50 */
+	uint32_t unused_13;			/* 0x54 */
+	uint32_t unused_14;			/* 0x58 */
+	uint32_t unused_15;			/* 0x5C */
+	uint32_t unused_16;			/* 0x60 */
+	uint32_t unused_17;			/* 0x64 */
+	uint32_t unused_18;			/* 0x68 */
+	uint32_t unused_19;			/* 0x6C */
+	uint32_t unused_20;			/* 0x70 */
+	uint32_t unused_21;			/* 0x74 */
+	uint32_t unused_22;			/* 0x78 */
+	uint32_t unused_23;			/* 0x7C */
 	uint32_t irq_mpforce[2];		/* 0x80 CPU 0*/
 						/* 0x84 CPU 1*/
-	UNUSED_UINT32_SLOT;			/* 0x88 */
-	UNUSED_UINT32_SLOT;			/* 0x8C */
-	UNUSED_UINT32_SLOT;			/* 0x90 */
-	UNUSED_UINT32_SLOT;			/* 0x94 */
-	UNUSED_UINT32_SLOT;			/* 0x98 */
-	UNUSED_UINT32_SLOT;			/* 0x9C */
-	UNUSED_UINT32_SLOT;			/* 0xA0 */
-	UNUSED_UINT32_SLOT;			/* 0xA4 */
-	UNUSED_UINT32_SLOT;			/* 0xA8 */
-	UNUSED_UINT32_SLOT;			/* 0xAC */
-	UNUSED_UINT32_SLOT;			/* 0xB0 */
-	UNUSED_UINT32_SLOT;			/* 0xB4 */
-	UNUSED_UINT32_SLOT;			/* 0xB8 */
-	UNUSED_UINT32_SLOT;			/* 0xBC */
+	uint32_t unused_24;			/* 0x88 */
+	uint32_t unused_25;			/* 0x8C */
+	uint32_t unused_26;			/* 0x90 */
+	uint32_t unused_27;			/* 0x94 */
+	uint32_t unused_28;			/* 0x98 */
+	uint32_t unused_29;			/* 0x9C */
+	uint32_t unused_30;			/* 0xA0 */
+	uint32_t unused_31;			/* 0xA4 */
+	uint32_t unused_32;			/* 0xA8 */
+	uint32_t unused_33;			/* 0xAC */
+	uint32_t unused_34;			/* 0xB0 */
+	uint32_t unused_35;			/* 0xB4 */
+	uint32_t unused_36;			/* 0xB8 */
+	uint32_t unused_37;			/* 0xBC */
 	uint32_t extended_irq_id[2];		/* 0xC0 CPU 0*/
 						/* 0xC4 CPU 1*/
 };

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -5,7 +5,7 @@
 DEBUGLEVEL ?= 3 #default build is with debug info
 CPPFLAGS += -DDEBUGLEVEL=$(DEBUGLEVEL)
 DEBUGFLAGS= -Wall -Wextra -Wcast-qual -Wshadow -Wdeclaration-after-statement \
-            -Wstrict-prototypes -Wpointer-arith -Wvla -Wformat=2 -Winit-self \
+            -Wstrict-prototypes -Wpointer-arith -Wformat=2 -Winit-self \
             -Wfloat-equal -Wwrite-strings \
             # -Wstrict-aliasing=1 -Wcast-align -Wredundant-decls -Wmissing-prototypes -Wundef -Wswitch-enum
 CFLAGS   += $(DEBUGFLAGS) $(MOREFLAGS)

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -8,7 +8,7 @@ DEBUGFLAGS= -Wall -Wextra -Wcast-qual -Wshadow -Wdeclaration-after-statement \
             -Wstrict-prototypes -Wpointer-arith -Wformat=2 -Winit-self \
             -Wfloat-equal -Wwrite-strings \
             # -Wstrict-aliasing=1 -Wcast-align -Wredundant-decls -Wmissing-prototypes -Wundef -Wswitch-enum
-CFLAGS   += $(DEBUGFLAGS) $(MOREFLAGS)
+CFLAGS   += -Icommon -std=gnu99 $(DEBUGFLAGS) $(MOREFLAGS)
 LDFLAGS  += $(MOREFLAGS)
 FLAGS     = $(CPPFLAGS) $(CFLAGS) $(LDFLAGS)
 
@@ -54,7 +54,7 @@ LOCAL_OBJ := $(LOCAL_OBJ0:.S=.o)
 
 
 lib-release: DEBUGFLAGS :=
-lib-release: CFLAGS := -O2
+lib-release: CFLAGS := -Icommon -O2 $(MOREFLAGS)
 lib-release: lib
 
 .PHONY: all

--- a/lib/common/cmp_debug.h
+++ b/lib/common/cmp_debug.h
@@ -19,7 +19,9 @@
 #ifndef CMP_DEBUG_H
 #define CMP_DEBUG_H
 
-#include <stdio.h>
+#ifndef ICU_ASW
+    #include <stdio.h>
+#endif
 
 #if defined(DEBUG) || DEBUGLEVEL > 0
 	__extension__

--- a/lib/common/cmp_debug.h
+++ b/lib/common/cmp_debug.h
@@ -20,10 +20,10 @@
 #define CMP_DEBUG_H
 
 #ifndef ICU_ASW
-    #include <stdio.h>
 #endif
 
-#if defined(DEBUG) || DEBUGLEVEL > 0
+#if !defined(ICU_ASW) && (defined(DEBUG) || DEBUGLEVEL > 0)
+	#include <stdio.h>
 	__extension__
 	#define debug_print(...) \
 		do { fprintf(stderr, __VA_ARGS__); } while (0)

--- a/lib/common/cmp_entity.c
+++ b/lib/common/cmp_entity.c
@@ -20,12 +20,15 @@
 
 #include <stdint.h>
 #include <string.h>
-#if defined __has_include
-#  if __has_include(<time.h>)
-#    include <time.h>
-#    include <stdlib.h>
-#    define HAS_TIME_H 1
-#    define my_timercmp(s, t, op) (((s)->tv_sec == (t)->tv_sec) ? ((s)->tv_nsec op (t)->tv_nsec) : ((s)->tv_sec op (t)->tv_sec))
+
+#ifndef ICU_ASW
+#  if defined __has_include
+#    if __has_include(<time.h>)
+#      include <time.h>
+#      include <stdlib.h>
+#      define HAS_TIME_H 1
+#      define my_timercmp(s, t, op) (((s)->tv_sec == (t)->tv_sec) ? ((s)->tv_nsec op (t)->tv_nsec) : ((s)->tv_sec op (t)->tv_sec))
+#    endif
 #  endif
 #endif
 
@@ -1692,7 +1695,6 @@ void *cmp_ent_get_data_buf(struct cmp_entity *ent)
  *
  * @returns the size in bytes to store the compressed data; negative on error
  *
- * @note the destination and source buffer can overlap
  * @note converts the data to the system endianness
  */
 
@@ -1726,7 +1728,7 @@ int32_t cmp_ent_get_cmp_data(struct cmp_entity *ent, uint32_t *data_buf,
 			return -1;
 		}
 
-		memmove(data_buf, cmp_ent_data_adr, cmp_size_byte);
+		memcpy(data_buf, cmp_ent_data_adr, cmp_size_byte);
 
 		cmp_data_len_32 = cmp_size_byte/sizeof(uint32_t);
 		for (i = 0; i < cmp_data_len_32; i++)

--- a/lib/common/stdint.h
+++ b/lib/common/stdint.h
@@ -1,0 +1,414 @@
+/*
+ * Copyright (c) 2004, 2005 by
+ * Ralf Corsepius, Ulm/Germany. All rights reserved.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * is freely granted, provided that this notice is preserved.
+ */
+
+/*
+ * @todo - Add support for wint_t types.
+ */
+
+#ifndef ICU_ASW
+
+__extension__
+#include_next <stdint.h>
+
+#else
+
+#ifndef _STDINT_H
+#define _STDINT_H
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if defined(__GNUC__) && \
+  ( (__GNUC__ >= 4) || \
+    ( (__GNUC__ >= 3) && defined(__GNUC_MINOR__) && (__GNUC_MINOR__ > 2) ) )
+/* gcc > 3.2 implicitly defines the values we are interested */
+#define __STDINT_EXP(x) __##x##__
+#else
+#define __STDINT_EXP(x) x
+#include <limits.h>
+#endif
+
+/* Check if "long long" is 64bit wide */
+/* Modern GCCs provide __LONG_LONG_MAX__, SUSv3 wants LLONG_MAX */
+#if ( defined(__LONG_LONG_MAX__) && (__LONG_LONG_MAX__ > 0x7fffffff) ) \
+  || ( defined(LLONG_MAX) && (LLONG_MAX > 0x7fffffff) )
+#define __have_longlong64 1
+#endif
+
+/* Check if "long" is 64bit or 32bit wide */
+#if __STDINT_EXP(LONG_MAX) > 0x7fffffff
+#define __have_long64 1
+#elif __STDINT_EXP(LONG_MAX) == 0x7fffffff && !defined(__SPU__)
+#define __have_long32 1
+#endif
+
+#if __STDINT_EXP(SCHAR_MAX) == 0x7f
+typedef signed char int8_t ;
+typedef unsigned char uint8_t ;
+#define __int8_t_defined 1
+#endif
+
+#if __int8_t_defined
+typedef signed char int_least8_t;
+typedef unsigned char uint_least8_t;
+#define __int_least8_t_defined 1
+#endif
+
+#if __STDINT_EXP(SHRT_MAX) == 0x7fff
+typedef signed short int16_t;
+typedef unsigned short uint16_t;
+#define __int16_t_defined 1
+#elif __STDINT_EXP(INT_MAX) == 0x7fff
+typedef signed int int16_t;
+typedef unsigned int uint16_t;
+#define __int16_t_defined 1
+#elif __STDINT_EXP(SCHAR_MAX) == 0x7fff
+typedef signed char int16_t;
+typedef unsigned char uint16_t;
+#define __int16_t_defined 1
+#endif
+
+#if __int16_t_defined
+typedef int16_t   	int_least16_t;
+typedef uint16_t 	uint_least16_t;
+#define __int_least16_t_defined 1
+
+#if !__int_least8_t_defined
+typedef int16_t	   	int_least8_t;
+typedef uint16_t  	uint_least8_t;
+#define __int_least8_t_defined 1
+#endif
+#endif
+
+#if __have_long32
+typedef signed long int32_t;
+typedef unsigned long uint32_t;
+#define __int32_t_defined 1
+#elif __STDINT_EXP(INT_MAX) == 0x7fffffffL
+typedef signed int int32_t;
+typedef unsigned int uint32_t;
+#define __int32_t_defined 1
+#elif __STDINT_EXP(SHRT_MAX) == 0x7fffffffL
+typedef signed short int32_t;
+typedef unsigned short uint32_t;
+#define __int32_t_defined 1
+#elif __STDINT_EXP(SCHAR_MAX) == 0x7fffffffL
+typedef signed char int32_t;
+typedef unsigned char uint32_t;
+#define __int32_t_defined 1
+#endif
+
+#if __int32_t_defined
+typedef int32_t   	int_least32_t;
+typedef uint32_t 	uint_least32_t;
+#define __int_least32_t_defined 1
+
+#if !__int_least8_t_defined
+typedef int32_t	   	int_least8_t;
+typedef uint32_t  	uint_least8_t;
+#define __int_least8_t_defined 1
+#endif
+
+#if !__int_least16_t_defined
+typedef int32_t	   	int_least16_t;
+typedef uint32_t  	uint_least16_t;
+#define __int_least16_t_defined 1
+#endif
+#endif
+
+#if __have_long64
+typedef signed long int64_t;
+typedef unsigned long uint64_t;
+#define __int64_t_defined 1
+#elif __have_longlong64
+typedef signed long long int64_t;
+typedef unsigned long long uint64_t;
+#define __int64_t_defined 1
+#elif  __STDINT_EXP(INT_MAX) > 0x7fffffff
+typedef signed int int64_t;
+typedef unsigned int uint64_t;
+#define __int64_t_defined 1
+#endif
+
+#if __int64_t_defined
+typedef int64_t   	int_least64_t;
+typedef uint64_t 	uint_least64_t;
+#define __int_least64_t_defined 1
+
+#if !__int_least8_t_defined
+typedef int64_t	   	int_least8_t;
+typedef uint64_t  	uint_least8_t;
+#define __int_least8_t_defined 1
+#endif
+
+#if !__int_least16_t_defined
+typedef int64_t	   	int_least16_t;
+typedef uint64_t  	uint_least16_t;
+#define __int_least16_t_defined 1
+#endif
+
+#if !__int_least32_t_defined
+typedef int64_t	   	int_least32_t;
+typedef uint64_t  	uint_least32_t;
+#define __int_least32_t_defined 1
+#endif
+#endif
+
+/*
+ * Fastest minimum-width integer types
+ *
+ * Assume int to be the fastest type for all types with a width
+ * less than __INT_MAX__ rsp. INT_MAX
+ */
+#if __STDINT_EXP(INT_MAX) >= 0x7f
+  typedef signed int int_fast8_t;
+  typedef unsigned int uint_fast8_t;
+#define __int_fast8_t_defined 1
+#endif
+
+#if __STDINT_EXP(INT_MAX) >= 0x7fff
+  typedef signed int int_fast16_t;
+  typedef unsigned int uint_fast16_t;
+#define __int_fast16_t_defined 1
+#endif
+
+#if __STDINT_EXP(INT_MAX) >= 0x7fffffff
+  typedef signed int int_fast32_t;
+  typedef unsigned int uint_fast32_t;
+#define __int_fast32_t_defined 1
+#endif
+
+#if __STDINT_EXP(INT_MAX) > 0x7fffffff
+  typedef signed int int_fast64_t;
+  typedef unsigned int uint_fast64_t;
+#define __int_fast64_t_defined 1
+#endif
+
+/*
+ * Fall back to [u]int_least<N>_t for [u]int_fast<N>_t types
+ * not having been defined, yet.
+ * Leave undefined, if [u]int_least<N>_t should not be available.
+ */
+#if !__int_fast8_t_defined
+#if __int_least8_t_defined
+  typedef int_least8_t int_fast8_t;
+  typedef uint_least8_t uint_fast8_t;
+#define __int_fast8_t_defined 1
+#endif
+#endif
+
+#if !__int_fast16_t_defined
+#if __int_least16_t_defined
+  typedef int_least16_t int_fast16_t;
+  typedef uint_least16_t uint_fast16_t;
+#define __int_fast16_t_defined 1
+#endif
+#endif
+
+#if !__int_fast32_t_defined
+#if __int_least32_t_defined
+  typedef int_least32_t int_fast32_t;
+  typedef uint_least32_t uint_fast32_t;
+#define __int_fast32_t_defined 1
+#endif
+#endif
+
+#if !__int_fast64_t_defined
+#if __int_least64_t_defined
+  typedef int_least64_t int_fast64_t;
+  typedef uint_least64_t uint_fast64_t;
+#define __int_fast64_t_defined 1
+#endif
+#endif
+
+/* Greatest-width integer types */
+/* Modern GCCs provide __INTMAX_TYPE__ */
+#if defined(__INTMAX_TYPE__)
+  typedef __INTMAX_TYPE__ intmax_t;
+#elif __have_longlong64
+  typedef signed long long intmax_t;
+#else
+  typedef signed long intmax_t;
+#endif
+
+/* Modern GCCs provide __UINTMAX_TYPE__ */
+#if defined(__UINTMAX_TYPE__)
+  typedef __UINTMAX_TYPE__ uintmax_t;
+#elif __have_longlong64
+  typedef unsigned long long uintmax_t;
+#else
+  typedef unsigned long uintmax_t;
+#endif
+
+/*
+ * GCC doesn't provide an appropriate macro for [u]intptr_t
+ * For now, use __PTRDIFF_TYPE__
+ */
+#if defined(__PTRDIFF_TYPE__)
+typedef signed __PTRDIFF_TYPE__ intptr_t;
+typedef unsigned __PTRDIFF_TYPE__ uintptr_t;
+#else
+/*
+ * Fallback to hardcoded values,
+ * should be valid on cpu's with 32bit int/32bit void*
+ */
+typedef signed long intptr_t;
+typedef unsigned long uintptr_t;
+#endif
+
+/* Limits of Specified-Width Integer Types */
+
+#if __int8_t_defined
+#define INT8_MIN 	-128
+#define INT8_MAX 	 127
+#define UINT8_MAX 	 255
+#endif
+
+#if __int_least8_t_defined
+#define INT_LEAST8_MIN 	-128
+#define INT_LEAST8_MAX 	 127
+#define UINT_LEAST8_MAX	 255
+#else
+#error required type int_least8_t missing
+#endif
+
+#if __int16_t_defined
+#define INT16_MIN 	-32768
+#define INT16_MAX 	 32767
+#define UINT16_MAX 	 65535
+#endif
+
+#if __int_least16_t_defined
+#define INT_LEAST16_MIN	-32768
+#define INT_LEAST16_MAX	 32767
+#define UINT_LEAST16_MAX 65535
+#else
+#error required type int_least16_t missing
+#endif
+
+#if __int32_t_defined
+#define INT32_MIN 	 (-2147483647-1)
+#define INT32_MAX 	 2147483647
+#define UINT32_MAX       4294967295U
+#endif
+
+#if __int_least32_t_defined
+#define INT_LEAST32_MIN  (-2147483647-1)
+#define INT_LEAST32_MAX  2147483647
+#define UINT_LEAST32_MAX 4294967295U
+#else
+#error required type int_least32_t missing
+#endif
+
+#if __int64_t_defined
+#if __have_long64
+#define INT64_MIN 	(-9223372036854775807L-1L)
+#define INT64_MAX 	 9223372036854775807L
+#define UINT64_MAX 	18446744073709551615U
+#elif __have_longlong64
+#define INT64_MIN 	(-9223372036854775807LL-1LL)
+#define INT64_MAX 	 9223372036854775807LL
+#define UINT64_MAX 	18446744073709551615ULL
+#endif
+#endif
+
+#if __int_least64_t_defined
+#if __have_long64
+#define INT_LEAST64_MIN  (-9223372036854775807L-1L)
+#define INT_LEAST64_MAX  9223372036854775807L
+#define UINT_LEAST64_MAX 18446744073709551615U
+#elif __have_longlong64
+#define INT_LEAST64_MIN  (-9223372036854775807LL-1LL)
+#define INT_LEAST64_MAX  9223372036854775807LL
+#define UINT_LEAST64_MAX 18446744073709551615ULL
+#endif
+#endif
+
+#if __int_fast8_t_defined
+#define INT_FAST8_MIN	INT8_MIN
+#define INT_FAST8_MAX	INT8_MAX
+#define UINT_FAST8_MAX	UINT8_MAX
+#endif
+
+#if __int_fast16_t_defined
+#define INT_FAST16_MIN	INT16_MIN
+#define INT_FAST16_MAX	INT16_MAX
+#define UINT_FAST16_MAX	UINT16_MAX
+#endif
+
+#if __int_fast32_t_defined
+#define INT_FAST32_MIN	INT32_MIN
+#define INT_FAST32_MAX	INT32_MAX
+#define UINT_FAST32_MAX	UINT32_MAX
+#endif
+
+#if __int_fast64_t_defined
+#define INT_FAST64_MIN	INT64_MIN
+#define INT_FAST64_MAX	INT64_MAX
+#define UINT_FAST64_MAX	UINT64_MAX
+#endif
+
+/* This must match size_t in stddef.h, currently long unsigned int */
+#define SIZE_MIN (-__STDINT_EXP(LONG_MAX) - 1L)
+#define SIZE_MAX __STDINT_EXP(LONG_MAX)
+
+/* This must match sig_atomic_t in <signal.h> (currently int) */
+#define SIG_ATOMIC_MIN (-__STDINT_EXP(INT_MAX) - 1)
+#define SIG_ATOMIC_MAX __STDINT_EXP(INT_MAX)
+
+/* This must match ptrdiff_t  in <stddef.h> (currently long int) */
+#define PTRDIFF_MIN (-__STDINT_EXP(LONG_MAX) - 1L)
+#define PTRDIFF_MAX __STDINT_EXP(LONG_MAX)
+
+/** Macros for minimum-width integer constant expressions */
+#define INT8_C(x)	x
+#define UINT8_C(x)	x##U
+
+#define INT16_C(x)	x
+#define UINT16_C(x)	x##U
+
+#if __have_long32
+#define INT32_C(x)	x##L
+#define UINT32_C(x)	x##UL
+#else
+#define INT32_C(x)	x
+#define UINT32_C(x)	x##U
+#endif
+
+#if __int64_t_defined
+#if __have_longlong64
+#define INT64_C(x)	x##LL
+#define UINT64_C(x)	x##ULL
+#else
+#define INT64_C(x)	x##L
+#define UINT64_C(x)	x##UL
+#endif
+#endif
+
+/** Macros for greatest-width integer constant expression */
+#if __have_longlong64
+#define INTMAX_C(x)	x##LL
+#define UINTMAX_C(x)	x##ULL
+#else
+#define INTMAX_C(x)	x##L
+#define UINTMAX_C(x)	x##UL
+#endif
+
+#ifdef __rtems__
+#include <machine/stdint.h>
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _STDINT_H */
+
+#endif /* ICU_ASW */

--- a/lib/decompress/decmp.c
+++ b/lib/decompress/decmp.c
@@ -2312,8 +2312,9 @@ int decompress_cmp_entiy(struct cmp_entity *ent, void *model_of_data,
 			 void *up_model_buf, void *decompressed_data)
 {
 	int err;
-	struct cmp_cfg cfg = {0};
+	struct cmp_cfg cfg;
 
+	memset(&cfg, 0, sizeof(struct cmp_cfg));
 	cfg.model_buf = model_of_data;
 	cfg.icu_new_model_buf = up_model_buf;
 	cfg.input_buf = decompressed_data;
@@ -2351,7 +2352,7 @@ int decompress_rdcu_data(uint32_t *compressed_data, const struct cmp_info *info,
 			 uint16_t *decompressed_data)
 
 {
-	struct cmp_cfg cfg = {0};
+	struct cmp_cfg cfg;
 
 	if (!compressed_data)
 		return -1;
@@ -2361,6 +2362,8 @@ int decompress_rdcu_data(uint32_t *compressed_data, const struct cmp_info *info,
 
 	if (info->cmp_err)
 		return -1;
+
+	memset(&cfg, 0, sizeof(struct cmp_cfg));
 
 	cfg.data_type = DATA_TYPE_IMAGETTE;
 	cfg.model_buf = model_of_data;

--- a/test/Makefile
+++ b/test/Makefile
@@ -5,7 +5,7 @@ DEBUGFLAGS= -Wall -Wextra -pedantic -Wcast-qual -Wshadow \
             -Wstrict-prototypes -Wpointer-arith \
             -Wvla -Wformat=2 -Winit-self -Wfloat-equal -Wwrite-strings \
             #-Wcast-align -Wredundant-decls -Wmissing-prototypes -Wundef -Wswitch-enum
-CFLAGS   += $(DEBUGFLAGS) $(MOREFLAGS)
+CFLAGS   += -std=gnu99 $(DEBUGFLAGS) $(MOREFLAGS)
 LDFLAGS  += $(MOREFLAGS)
 FLAGS     = $(CPPFLAGS) $(CFLAGS) $(LDFLAGS)
 


### PR DESCRIPTION
Include a stdint.h if the compiler does not provide 
Replace memmove with memcpy in cmp_ent_get_cmp_data() function (data_buf and ent shouldn't overlap now)
The stdio.h is removed when not needed
rename sync() functions (overlapping with RTEMS function)
replace __COUNTER__ macro
remove  -Wvla warning
replace struct xx ={0} with memset