### PR TITLE
Enhanced Error Handling in Chunk Compression Functions

### DIFF
--- a/lib/common/cmp_debug.h
+++ b/lib/common/cmp_debug.h
@@ -41,5 +41,12 @@ void cmp_debug_print_impl(const char *fmt, ...);
 #  define debug_print(...) do {} while (0)
 #endif
 
+#define debug_print_level(level, ...)			\
+	do {						\
+		if (level <= DEBUGLEVEL)		\
+			debug_print(__VA_ARGS__);	\
+	} while (0)
+
+
 
 #endif /* CMP_DEBUG_H */

--- a/lib/common/cmp_error.c
+++ b/lib/common/cmp_error.c
@@ -1,0 +1,141 @@
+/**
+ * @file   cmp_error.c
+ * @author Dominik Loidolt (dominik.loidolt@univie.ac.at)
+ * @date   2024
+ *
+ * @copyright GPLv2
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * @brief handling errors functions
+ */
+
+#include <stdint.h>
+
+#include "cmp_error.h"
+#include "cmp_error_list.h"
+#include "../cmp_chunk.h"
+
+
+/**
+ * @brief tells if a result is an error code
+ *
+ * @param code	return value to check
+ *
+ * @returns non-zero if the code is an error
+ */
+
+unsigned int cmp_is_error(uint32_t code)
+{
+	return (code > CMP_ERROR(MAX_CODE));
+}
+
+
+/**
+ * @brief convert a function result into a cmp_error enum
+ *
+ * @param code	compression return value to get the error code
+ *
+ * @returns error code
+ */
+
+enum cmp_error cmp_get_error_code(uint32_t code)
+{
+	if (cmp_is_error(code))
+		return (enum cmp_error)(0-code);
+
+	return CMP_ERROR_NO_ERROR;
+}
+
+
+/**
+ * @brief get a string describing an error code
+ *
+ * @param code	the error code to describe, obtain with cmp_get_error_code()
+ *
+ * @returns a pointer to a string literal that describes the error code.
+ */
+
+const char* cmp_get_error_string(enum cmp_error code)
+{
+#ifdef CMP_STRIP_ERROR_STRINGS
+	(void)code;
+	return "Error strings stripped";
+#else
+	static const char* const notErrorCode = "Unspecified error code";
+	switch (code) {
+	case CMP_ERROR_NO_ERROR:
+		return "No error detected";
+	case CMP_ERROR_GENERIC:
+		return "Error (generic)";
+	case CMP_ERROR_SMALL_BUF_:
+		return "Destination buffer is too small to hold the whole compressed data";
+	case CMP_ERROR_DATA_VALUE_TOO_LARGE:
+		return "Data value is larger than expected";
+
+
+	case CMP_ERROR_PAR_GENERIC:
+		return "Compression mode or model value or lossy rounding parameter is unsupported";
+	case CMP_ERROR_PAR_SPECIFIC:
+		return "Specific compression parameters or combination is unsupported";
+	case CMP_ERROR_PAR_BUFFERS:
+		return "Buffer related parameter is not valid";
+
+	case CMP_ERROR_CHUNK_NULL:
+		return "Pointer to the chunk is NULL. No data, no compression";
+	case CMP_ERROR_CHUNK_TOO_LARGE:
+		return "Chunk size too large";
+	case CMP_ERROR_CHUNK_TOO_SMALL:
+		return "Chunk size too small. Minimum size is the size of a collection header";
+	case CMP_ERROR_CHUNK_SIZE_INCONSISTENT:
+		return "Chunk size is not consistent with the sum of the sizes in the compression headers. Chunk size may be wrong?";
+	case CMP_ERROR_CHUNK_SUBSERVICE_INCONSISTENT:
+		return "The chunk contains collections with an incompatible combination of subservices";
+
+	case CMP_ERROR_COL_SUBSERVICE_UNSUPPORTED:
+		return "Unsupported collection subservice";
+	case CMP_ERROR_COL_SIZE_INCONSISTENT:
+		return "Inconsistency detected between the collection subservice and data length";
+
+	case CMP_ERROR_ENTITY_NULL:
+		return "Compression entity pointer is NULL";
+	case CMP_ERROR_ENTITY_TOO_SMALL:
+		return "Compression entity size is too small";
+	case CMP_ERROR_ENTITY_HEADER:
+		return "An error occurred while generating the compression entity header";
+	case CMP_ERROR_ENTITY_TIMESTAMP:
+		return "Timestamp too large for the compression entity header";
+
+	case CMP_ERROR_INT_DECODER:
+		return "Internal decoder error occurred";
+	case CMP_ERROR_INT_DATA_TYPE_UNSUPPORTED:
+		return "Internal error: Data type not supported";
+	case CMP_ERROR_INT_CMP_COL_TOO_LARGE:
+		return "Internal error: compressed collection to large";
+
+	case CMP_ERROR_MAX_CODE:
+	default:
+		return notErrorCode;
+    }
+#endif
+}
+
+
+/**
+ * @brief provides a readable string from a compression return value (useful for debugging)
+ *
+ * @param code	compression return value to describe
+ *
+ * @returns a pointer to a string literal that describes the error code.
+ */
+
+const char* cmp_get_error_name(uint32_t code)
+{
+	return cmp_get_error_string(cmp_get_error_code(code));
+}

--- a/lib/common/cmp_error.h
+++ b/lib/common/cmp_error.h
@@ -1,0 +1,149 @@
+/**
+ * @file   cmp_error.h
+ * @author Dominik Loidolt (dominik.loidolt@univie.ac.at)
+ * @date   2024
+ *
+ * @copyright GPLv2
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * @brief collection of macros to handling errors
+ * This is heavy inspired by the error handling of zstd (lib/common/error_private.h) by
+ * @author Yann Collet et al.
+ * https://github.com/facebook/zstd/blob/dev/
+ */
+
+#ifndef CMP_ERROR_H
+#define CMP_ERROR_H
+
+
+#include <stdint.h>
+#include "cmp_error_list.h"
+
+
+/**
+ * @brief add the CMP_ERROR prefix to the error name
+ *
+ * @param name the name to concatenate with cmp error prefix
+ */
+
+#define PREFIX_CMP_ERRROR(name) CMP_ERROR_##name
+
+
+/**
+ * @brief generate a return value of a error
+ *
+ * @param name	 error name without CMP_ERROR prefix to create an error code for
+ */
+
+#define CMP_ERROR(name) ((uint32_t)-PREFIX_CMP_ERRROR(name))
+
+
+/**
+ * @brief ignore this is an internal helper
+ *
+ * this is a helper function to help force c99-correctness during compilation
+ * under strict compilation modes variadic macro arguments can't be empty
+ * however variadic function arguments can be using a function therefore lets
+ * us statically check that at least one string argument was passed
+ * independent of the compilation flags
+ */
+
+static __inline void _force_has_format_string(const char *format, ...) {
+	(void)format;
+}
+
+
+/**
+ * @brief ignore this is an internal helper
+ *
+ * we want to force this function invocation to be syntactically correct but
+ * we don't want to force runtime evaluation of its arguments
+ */
+
+__extension__
+#define _FORCE_HAS_FORMAT_STRING(...)				\
+	do {							\
+		if (0) {					\
+			_force_has_format_string(__VA_ARGS__);	\
+		}						\
+	} while (0)
+
+#define ERR_QUOTE(str) #str
+
+
+/**
+ * @brief return the specified error if the condition evaluates to true
+ *
+ * @param cond	 the condition to evaluate
+ * @param err	the error to return if the condition is true
+ * @param ...	 additional arguments for error logging
+ *
+ * in debug modes (DEBUGLEVEL>=3) prints additional information
+ */
+
+__extension__
+#define RETURN_ERROR_IF(cond, err, ...)								\
+	do {											\
+		if (cond) {									\
+			debug_print_level(3, "%s:%d: Error: check %s failed, returning %s",	\
+					  __FILE__, __LINE__, ERR_QUOTE(cond),			\
+					  ERR_QUOTE(CMP_ERROR(err)));				\
+			_FORCE_HAS_FORMAT_STRING(__VA_ARGS__);					\
+			debug_print_level(3, "-> " __VA_ARGS__);				\
+			return CMP_ERROR(err);							\
+		}										\
+	} while (0)
+
+
+/**
+ * @brief unconditionally return the specified error
+ *
+ * @param err	the error to return unconditionally
+ * @param ...	additional arguments for error logging
+ *
+ * in debug modes (DEBUGLEVEL>=3) prints additional information
+ */
+
+__extension__
+#define RETURN_ERROR(err, ...)									\
+	do {											\
+		debug_print_level(3, "%s:%d: Error: unconditional check failed, returning %s",	\
+				  __FILE__, __LINE__, ERR_QUOTE(ERROR(err)));			\
+		_FORCE_HAS_FORMAT_STRING(__VA_ARGS__);						\
+		debug_print_level(3, "-> " __VA_ARGS__);					\
+		return CMP_ERROR(err);								\
+	} while(0)
+
+
+/**
+ * @brief if the provided expression evaluates to an error code returns that error code
+ *
+ * @param err	the error expression to evaluate
+ * @param ...	additional arguments for error logging
+ *
+ * in debug modes (DEBUGLEVEL>=3) prints additional information
+ */
+
+__extension__
+#define FORWARD_IF_ERROR(err, ...)							\
+	do {										\
+		uint32_t const err_code = (err);					\
+		if (cmp_is_error(err_code)) {						\
+			debug_print_level(3, "%s:%d: Error: forwarding error in %s: %s",\
+					  __FILE__, __LINE__, ERR_QUOTE(err),		\
+					  cmp_get_error_name(err_code));		\
+			_FORCE_HAS_FORMAT_STRING(__VA_ARGS__);				\
+			debug_print_level(3, "--> " __VA_ARGS__);			\
+			return err_code;						\
+		}									\
+	} while(0)
+
+
+#endif /* CMP_ERROR_H */

--- a/lib/common/cmp_error_list.h
+++ b/lib/common/cmp_error_list.h
@@ -1,0 +1,59 @@
+/**
+ * @file   cmp_error_list.h
+ * @author Dominik Loidolt (dominik.loidolt@univie.ac.at)
+ * @date   2024
+ *
+ * @copyright GPLv2
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * @brief definition of the compression error codes
+ */
+
+#ifndef CMP_ERROR_LIST_H
+#define CMP_ERROR_LIST_H
+
+
+/**
+ * @brief compression error codes
+ * @warning error codes (name and value) are TBC
+ */
+
+enum cmp_error {
+	CMP_ERROR_NO_ERROR = 0,
+	CMP_ERROR_GENERIC = 1,
+	CMP_ERROR_SMALL_BUF_ = 2,
+	CMP_ERROR_DATA_VALUE_TOO_LARGE = 3,
+	/* compression parameter errors */
+	CMP_ERROR_PAR_GENERIC = 20,
+	CMP_ERROR_PAR_SPECIFIC = 21,
+	CMP_ERROR_PAR_BUFFERS = 22,
+	/* chunk errors */
+	CMP_ERROR_CHUNK_NULL = 40,
+	CMP_ERROR_CHUNK_TOO_LARGE = 41,
+	CMP_ERROR_CHUNK_TOO_SMALL = 42,
+	CMP_ERROR_CHUNK_SIZE_INCONSISTENT = 43,
+	CMP_ERROR_CHUNK_SUBSERVICE_INCONSISTENT = 44,
+	/* collection errors */
+	CMP_ERROR_COL_SUBSERVICE_UNSUPPORTED = 60,
+	CMP_ERROR_COL_SIZE_INCONSISTENT = 61,
+	/* compression entity errors */
+	CMP_ERROR_ENTITY_NULL = 80,
+	CMP_ERROR_ENTITY_TOO_SMALL = 81,
+	CMP_ERROR_ENTITY_HEADER = 82,
+	CMP_ERROR_ENTITY_TIMESTAMP = 83,
+	/* internal compressor errors */
+	CMP_ERROR_INT_DECODER = 100,
+	CMP_ERROR_INT_DATA_TYPE_UNSUPPORTED = 101,
+	CMP_ERROR_INT_CMP_COL_TOO_LARGE = 102,
+
+	CMP_ERROR_MAX_CODE = 127 /* Prefer using cmp_is_error() for error checking. */
+};
+
+#endif /* CMP_ERROR_LIST_H */


### PR DESCRIPTION
- The compression function has been updated to return an error code upon failure.
- The returned value can now be checked for errors using the cmp_is_error() function.
- Retrieve the specific error code with the cmp_get_error_code() function.
- Error handling now includes descriptive strings for each error code.
- DEBUGLEVEL >=3 for debug information
- Note: compress_chunk_set_model_id_and_counter() will return dst_size on success instead of 0.