### PR TITLE
Silently forward error without debug message in compress_data_internal

### DIFF
--- a/lib/icu_compress/cmp_icu.c
+++ b/lib/icu_compress/cmp_icu.c
@@ -2230,7 +2230,9 @@ static uint32_t compress_data_internal(const struct cmp_cfg *cfg, uint32_t strea
 		/* LCOV_EXCL_STOP */
 	}
 
-	FORWARD_IF_ERROR(bitsize, "");
+	if (cmp_is_error(bitsize))
+		return bitsize;
+
 	bitsize = pad_bitstream(cfg, bitsize);
 
 	return bitsize;


### PR DESCRIPTION
Resolved a bug that caused an error message
("../lib/icu_compress/cmp_icu.c:2229: Error: forwarding error in bitsize: ...") to display when DEBUGLEVEL is set to 3. This behavior is unintended as the compressor is designed to handle such errors by inserting the uncompressed data directly into the bitstream. Consequently, the error forwarding process has been made silent.