### PR TITLE
Changed variance_mean fields in struct smearing

### DIFF
--- a/lib/common/cmp_data_types.c
+++ b/lib/common/cmp_data_types.c
@@ -646,7 +646,7 @@ static void be_to_cpus_smearing(struct smearing *a, uint32_t samples)
 
 	for (i = 0; i < samples; i++) {
 		a[i].mean = be32_to_cpu(a[i].mean);
-		a[i].variance_mean = be16_to_cpu(a[i].variance_mean);
+		a[i].variance_mean = be32_to_cpu(a[i].variance_mean);
 		a[i].outlier_pixels = be16_to_cpu(a[i].outlier_pixels);
 	}
 }

--- a/lib/common/cmp_data_types.h
+++ b/lib/common/cmp_data_types.h
@@ -293,7 +293,7 @@ struct background {
 
 struct smearing {
 	uint32_t mean;
-	uint16_t variance_mean;
+	uint32_t variance_mean;
 	uint16_t outlier_pixels;
 } __attribute__((packed));
 

--- a/lib/rdcu_compress/rdcu_rmap.c
+++ b/lib/rdcu_compress/rdcu_rmap.c
@@ -65,7 +65,6 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
-#include <alloca.h>
 
 #include "../common/byteorder.h"
 #include "../common/cmp_debug.h"

--- a/test/cmp_data_types/test_cmp_data_types.c
+++ b/test/cmp_data_types/test_cmp_data_types.c
@@ -366,11 +366,11 @@ void test_be_to_cpu_chunk(void)
 		data_type = DATA_TYPE_SMEARING;
 
 		data.entry[0].mean           = 0x00010203;
-		data.entry[0].variance_mean  = 0x0405;
-		data.entry[0].outlier_pixels = 0x0607;
-		data.entry[1].mean           = 0x08090A0B;
-		data.entry[1].variance_mean  = 0x0C0D;
-		data.entry[1].outlier_pixels = 0x0E0F;
+		data.entry[0].variance_mean  = 0x04050607;
+		data.entry[0].outlier_pixels = 0x0809;
+		data.entry[1].mean           = 0x0A0B0C0D;
+		data.entry[1].variance_mean  = 0x0E0F1011;
+		data.entry[1].outlier_pixels = 0x1213;
 
 		check_endianness(&data, sizeof(data), data_type);
 	}

--- a/test/cmp_entity/test_cmp_entity.c
+++ b/test/cmp_entity/test_cmp_entity.c
@@ -216,7 +216,7 @@ void test_ent_start_timestamp(void)
 	TEST_ASSERT_FALSE(error);
 
 	start_timestamp_read = cmp_ent_get_start_timestamp(&ent);
-	TEST_ASSERT_EQUAL_UINT64(start_timestamp, start_timestamp_read);
+	TEST_ASSERT_EQUAL(start_timestamp, start_timestamp_read);
 
 	/* check the right position in the header */
 	TEST_ASSERT_EQUAL_HEX(0x12, entity_p[10]);
@@ -227,9 +227,9 @@ void test_ent_start_timestamp(void)
 	TEST_ASSERT_EQUAL_HEX(0xBC, entity_p[15]);
 
 	coarse_start_timestamp_read = cmp_ent_get_coarse_start_time(&ent);
-	TEST_ASSERT_EQUAL_UINT64(0x12345678, coarse_start_timestamp_read);
+	TEST_ASSERT_EQUAL(0x12345678, coarse_start_timestamp_read);
 	fine_start_timestamp_read = cmp_ent_get_fine_start_time(&ent);
-	TEST_ASSERT_EQUAL_UINT64(0x9ABC, fine_start_timestamp_read);
+	TEST_ASSERT_EQUAL(0x9ABC, fine_start_timestamp_read);
 
 	/* error cases */
 	start_timestamp = 0x1000000000000ULL;
@@ -328,7 +328,7 @@ void test_ent_end_timestamp(void)
 	TEST_ASSERT_FALSE(error);
 
 	end_timestamp_read = cmp_ent_get_end_timestamp(&ent);
-	TEST_ASSERT_EQUAL_HEX64(end_timestamp, end_timestamp_read);
+	TEST_ASSERT_EQUAL(end_timestamp, end_timestamp_read);
 
 	/* check the right position in the header */
 	TEST_ASSERT_EQUAL_HEX(0x12, entity_p[16]);
@@ -339,9 +339,9 @@ void test_ent_end_timestamp(void)
 	TEST_ASSERT_EQUAL_HEX(0xBC, entity_p[21]);
 
 	coarse_end_timestamp_read = cmp_ent_get_coarse_end_time(&ent);
-	TEST_ASSERT_EQUAL_UINT64(0x12345678, coarse_end_timestamp_read);
+	TEST_ASSERT_EQUAL(0x12345678, coarse_end_timestamp_read);
 	fine_end_timestamp_read = cmp_ent_get_fine_end_time(&ent);
-	TEST_ASSERT_EQUAL_UINT64(0x9ABC, fine_end_timestamp_read);
+	TEST_ASSERT_EQUAL(0x9ABC, fine_end_timestamp_read);
 
 	/* error cases */
 	end_timestamp = 0x1000000000000ULL;
@@ -1867,7 +1867,7 @@ void test_cmp_ent_create_timestamp(void)
 	ts.tv_nsec = 0;
 	timestamp1 = cmp_ent_create_timestamp(&ts);
 	ts.tv_sec = EPOCH + 1;
-	ts.tv_nsec = 15258;
+	ts.tv_nsec = 15259;
 	timestamp2 = cmp_ent_create_timestamp(&ts);
 	TEST_ASSERT_EQUAL_HEX(0x10001, timestamp2-timestamp1);
 


### PR DESCRIPTION
- Changed variance_mean fields in struct smearing from uint16_t to uint32_t to match current smearing definition
- Updated corresponding endianness conversion in be_to_cpus_smearing()
- Adjusted unit tests to reflect new field size